### PR TITLE
Correct password hashing

### DIFF
--- a/tacview/client.go
+++ b/tacview/client.go
@@ -4,13 +4,28 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"hash/crc64"
+	"io"
 	"math/bits"
 	"net"
 	"unicode/utf16"
 )
 
-func hashPassword(password string) uint64 {
+func hashPassword32(password string) string {
+	password_utf16 := utf16.Encode([]rune(password))
+
+	password_bytes := make([]byte, 2*len(password_utf16))
+	for i, r := range password_utf16 {
+		password_bytes[2*i+0] = byte(r >> 0)
+		password_bytes[2*i+1] = byte(r >> 8)
+	}
+
+	hash := crc32.ChecksumIEEE(password_bytes)
+	return fmt.Sprintf("%x", hash)
+}
+
+func hashPassword64(password string) string {
 	password_utf16 := utf16.Encode([]rune(password))
 
 	password_bytes := make([]byte, 2*len(password_utf16))
@@ -19,12 +34,22 @@ func hashPassword(password string) uint64 {
 		password_bytes[2*i+1] = bits.Reverse8(byte(r >> 8))
 	}
 
-	hash := crc64.Checksum(password_bytes, crc64.MakeTable(crc64.ECMA))
-	return bits.Reverse64(hash)
+	hash := bits.Reverse64(crc64.Checksum(password_bytes, crc64.MakeTable(crc64.ECMA)))
+	return fmt.Sprintf("%x", hash)
 }
 
 /// Creates a new Reader from a TacView Real Time server
 func NewRealTimeReader(connStr string, username string, password string) (*Reader, error) {
+	reader, err := newRealTimeReaderHash(connStr, username, password, hashPassword64)
+
+	if err == io.EOF {
+		reader, err = newRealTimeReaderHash(connStr, username, password, hashPassword32)
+	}
+
+	return reader, err
+}
+
+func newRealTimeReaderHash(connStr string, username string, password string, hasher func(string) string) (*Reader, error) {
 	conn, err := net.Dial("tcp", connStr)
 	if err != nil {
 		return nil, err
@@ -71,23 +96,15 @@ func NewRealTimeReader(connStr string, username string, password string) (*Reade
 	if err != nil {
 		return nil, err
 	}
-	_, err = conn.Write([]byte(fmt.Sprintf("Client %s\n", username)))
+	_, err = conn.Write([]byte(fmt.Sprintf("%s\n", username)))
 	if err != nil {
 		return nil, err
 	}
 
-	if password != "" {
-		hash := hashPassword(password)
-
-		_, err = conn.Write([]byte(fmt.Sprintf("%x\x00\n", hash)))
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		_, err = conn.Write([]byte("\x00\n"))
-		if err != nil {
-			return nil, err
-		}
+	hash := hashPassword64(password)
+	_, err = conn.Write([]byte(fmt.Sprintf("%x\x00", hash)))
+	if err != nil {
+		return nil, err
 	}
 
 	return NewReader(reader)

--- a/tacview/client_test.go
+++ b/tacview/client_test.go
@@ -1,0 +1,21 @@
+package tacview
+
+import (
+	"testing"
+)
+
+func testHash(password string, expected uint64, t *testing.T) {
+	hash := hashPassword(password)
+	if hash != expected {
+		t.Fatalf("Hash mismatch for \"%s\"; expected %x, calculated %x.", password, expected, hash)
+	}
+}
+
+func TestHashPassword(t *testing.T) {
+	testHash("",         0x0000000000000000, t)
+	testHash("pass",     0x5e1e445fd60ac2e0, t)
+	testHash("password", 0x3c0e55f1cfff14c4, t)
+	testHash("abc",      0xfc99a9ae7dfa5bfc, t)
+	testHash("abc123",   0x2bd464b05d7103f1, t)
+	testHash("12345",    0x6b40207b495297f4, t)
+}

--- a/tacview/client_test.go
+++ b/tacview/client_test.go
@@ -4,18 +4,34 @@ import (
 	"testing"
 )
 
-func testHash(password string, expected uint64, t *testing.T) {
-	hash := hashPassword(password)
+func testHash32(password string, expected string, t *testing.T) {
+	hash := hashPassword32(password)
 	if hash != expected {
-		t.Fatalf("Hash mismatch for \"%s\"; expected %x, calculated %x.", password, expected, hash)
+		t.Fatalf("Hash32 mismatch for \"%s\"; expected %s, calculated %s.", password, expected, hash)
 	}
 }
 
-func TestHashPassword(t *testing.T) {
-	testHash("",         0x0000000000000000, t)
-	testHash("pass",     0x5e1e445fd60ac2e0, t)
-	testHash("password", 0x3c0e55f1cfff14c4, t)
-	testHash("abc",      0xfc99a9ae7dfa5bfc, t)
-	testHash("abc123",   0x2bd464b05d7103f1, t)
-	testHash("12345",    0x6b40207b495297f4, t)
+func testHash64(password string, expected string, t *testing.T) {
+	hash := hashPassword64(password)
+	if hash != expected {
+		t.Fatalf("Hash64 mismatch for \"%s\"; expected %s, calculated %s.", password, expected, hash)
+	}
+}
+
+func TestHashPassword32(t *testing.T) {
+	testHash32("",         "0",        t)
+	testHash32("pass",     "7742b741", t)
+	testHash32("password", "f335183e", t)
+	testHash32("abc",      "ad957ab0", t)
+	testHash32("abc123",   "223b140f", t)
+	testHash32("12345",    "fcc50d33", t)
+}
+
+func TestHashPassword64(t *testing.T) {
+	testHash64("",         "0",                t)
+	testHash64("pass",     "5e1e445fd60ac2e0", t)
+	testHash64("password", "3c0e55f1cfff14c4", t)
+	testHash64("abc",      "fc99a9ae7dfa5bfc", t)
+	testHash64("abc123",   "2bd464b05d7103f1", t)
+	testHash64("12345",    "6b40207b495297f4", t)
 }


### PR DESCRIPTION
Trying to connect to the DCS World exporter's real-time telemetry with a password doesn't work.

When trying to connect to the real-time telemetry in the DCS plug-in with a password set, Sneaker's Tacview session always immediately disconnects with EOF. This seems to be consistent with Tacview's documentation that the server should close the connection if the password does not match. The Tacview application itself is able to connect with the password and display telemetry.

Sniffing at the connections (with a password of "pass") a bit with Wireshark, I saw a few things of note:
1. Sneaker is sending the hash in decimal. The documentation does mention it should be in hexadecimal, and the Tacview application is indeed doing so. This is a trivial fix.
2. Even when the correct base is used, the hashes being sent are different. This is a bit more complicated.
3. Tacview doesn't connect on the first attempt; instead, it makes a second connection attempt with a shorter hash, and this is what actually works. Tacview is doing something undocumented!
4. Tacview doesn't send the word "Client" prior to the username.

Sneaker:
```
XtraLib.Stream.0
Tacview.RealTimeTelemetry.0
Client sneakerserver
5619059226115564798␀␤
```

Tacview Connection 1:
```
XtraLib.Stream.0
Tacview.RealTimeTelemetry.0
Barinzaya
5e1e445fd60ac2e0␀
```

Tacview Connection 2:
```
XtraLib.Stream.0
Tacview.RealTimeTelemetry.0
Barinzaya
7742b741␀
```

I found [a thread on the Tacview/Dogs of War forums](http://dogsofwarvu.com/forum/index.php/topic,8706.msg45203.html) that discussed the behavior of the CRC. There are two major things of note here:
- The data that the hash is performed on must be UTF-16(-ish). This isn't mentioned in the documentation, and is a bit odd considering that nothing else in the protocol is UTF-16.
- The DCS exporter doesn't actually support the CRC-64 hash that the documentation says the protocol uses, and instead uses a CRC32 hash. This is the second connection attempt that actually works.

Checking with [an online CRC calculator](http://www.sunshine2k.de/coding/javascript/crc/crc_js.html), I've found the following.

Sneaker's hash (5619059226115564798, hex 4dfae898587fe4fe) matches up with the following settings:
- Bytes: 70 61 73 73 ("pass" in UTF-8)
- Polynomial: 0x42F0E1EBA9EA3693 (CRC-64-ECMA-182 polynomial)
- Initial value: 0xFFFFFFFFFFFFFFFF
- Final XOR value: 0xFFFFFFFFFFFFFFFF
- Both input and output reflected

Tacview's CRC-64 hash (5e1e445fd60ac2e0) matches up with the following settings:
- **Bytes: 70 00 61 00 73 00 73 00 ("pass" in UTF-16-LE)**
- Polynomial: 0x42F0E1EBA9EA3693 (CRC-64-ECMA-182 polynomial)
- Initial value: 0xFFFFFFFFFFFFFFFF
- Final XOR value: 0xFFFFFFFFFFFFFFFF
- **Neither input nor output reflected**
 
Tacview's CRC-32 hash works with the regular CRC32 preset.

There are two things that don't match up between the CRC-64 hashes:
- The password needs to be converted to UTF-16-LE prior to hashing. This means a pass through `encoding/utf16`, and then extracting the individual bytes from the resulting runes.
- The input and result need to be reflected. Per [a write-up from the person that created the calculator linked above](http://www.sunshine2k.de/articles/coding/crc/understanding_crc.html#ch71), reflecting these values means reversing the bits on each byte of the input, and also reversing the bits in the resulting hash. Both of these can be done relatively easily using the ReverseX functions in `math/bits`.

After implementing these changes, the hashes now match up with those produced by the Tacview application. This still doesn't allow Sneaker to connect to the DCS exporter, though.

As for the CRC32 implementation, that's more straightforward. It matches up directly with the IEEE checksum implemented in `hash/crc32`, with no bit reversals necessary. The UTF-16 conversion is still necessary, of course. There's also a bit of extra logic that's needed to retry the connection using the CRC32 hash if the CRC64 hash fails, like Tacview does, but that's just a matter of checking for an EOF error and trying again in that case.

I'm not sure if there are any other tools that are built to work with the way that Jambon was hashing the passwords before, but if so, an additional retry step could easily be added using the old style of hashing (direct CRC-64-ECMA on the UTF-8 string, then encoding in decimal).

I've also added unit tests for the hashing functions, which test hashes of several passwords and compare them to the corresponding hashes that were produced by the Tacview application (sniffed via Wireshark), just to ensure that things are consistent.

With these changes made, I am now able to connect Sneaker to the DCS exporter's real-time telemetry when a password is required.